### PR TITLE
Fail if expires is missing and expiry check is turned on

### DIFF
--- a/altcha/altcha.py
+++ b/altcha/altcha.py
@@ -324,7 +324,7 @@ def verify_solution(payload, hmac_key, check_expires):
 
     expires = extract_params(payload).get("expires")
     try:
-        if check_expires and expires and int(expires[0]) < time.time():
+        if check_expires and (not expires or int(expires[0]) < time.time()):
             return False, None
     except ValueError:  # Guard against malformed expires
         return False, None

--- a/tests/test_altcha.py
+++ b/tests/test_altcha.py
@@ -130,6 +130,29 @@ class TestALTCHA(unittest.TestCase):
         result, _ = verify_solution(payload_encoded, self.hmac_key, check_expires=True)
         self.assertFalse(result)
 
+    def test_verify_solution_expires_missing(self):
+        options = ChallengeOptions(
+            algorithm="SHA-256",
+            max_number=1000,
+            salt_length=16,
+            hmac_key=self.hmac_key,
+            salt="somesalt",
+            number=123,
+        )
+        challenge = create_challenge(options)
+        payload = Payload(
+            algorithm="SHA-256",
+            challenge=challenge.challenge,
+            number=123,
+            salt=challenge.salt,
+            signature=challenge.signature,
+        )
+        payload_encoded = base64.b64encode(
+            json.dumps(payload.__dict__).encode()
+        ).decode()
+        result, _ = verify_solution(payload_encoded, self.hmac_key, check_expires=True)
+        self.assertFalse(result)
+
     def test_verify_solution_malformed_expiry(self):
         options = ChallengeOptions(
             algorithm="SHA-256",


### PR DESCRIPTION
Skipping the verification if expires is missing brings false expectation that expiry has been checked.