### PR TITLE
Drop support for unsupported Python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.9',
     install_requires=[
         # Add any dependencies here
     ],


### PR DESCRIPTION
See https://devguide.python.org/versions/