### PR TITLE
fix: set default number to None (ChallengeOptions)

### DIFF
--- a/altcha/altcha.py
+++ b/altcha/altcha.py
@@ -55,7 +55,7 @@ class ChallengeOptions:
         salt_length: int = DEFAULT_SALT_LENGTH,
         hmac_key: str = "",
         salt: str = "",
-        number: int = 0,
+        number: int | None = None,
         expires: datetime.datetime | None = None,
         params: dict[str, str] | None = None,
     ):


### PR DESCRIPTION
**Problem**

The previous default value of `ChallengeOptions.number = 0` did not trigger the random initialization of number when calling `create_challenge`. This resulted in trivial challenges that could be solved in microseconds, undermining the intended difficulty.

**Example**

The following code illustrates the issue, showing how challenges with number = 0 are trivial to solve:

```python
import datetime
from altcha import ChallengeOptions, create_challenge, solve_challenge

hmac_key = "secret hmac key"

# Create a new challenge
options = ChallengeOptions(
    expires=datetime.datetime.now() + datetime.timedelta(hours=1),
    max_number=1_000_000,  # The maximum random number
    hmac_key=hmac_key,
)
challenge = create_challenge(options)

solution = solve_challenge(
    challenge.challenge,
    challenge.salt,
    challenge.algorithm,
    challenge.maxnumber,
    start=0,
)
print(f"Challenge took {solution.took} seconds.")
```

In this example, the challenge is solved almost instantly.

**Impact**

This issue affects the current ALTCHA widgets, as they solve these improperly initialized challenges much faster than intended.

**Proposed Fix**

This pull request updates the behavior to ensure number is properly randomized if not explicitly set (`number: int | None = None`). If set to `None` a [random number is chosen in `create_challenge`](https://github.com/altcha-org/altcha-lib-py/blob/bea449c56370810ff525370bc745f8c7a0429310/altcha/altcha.py#L289).