### PR TITLE
feat altcha.py verify_solution returns False, "Altcha payload expired"

### DIFF
--- a/altcha/altcha.py
+++ b/altcha/altcha.py
@@ -342,9 +342,9 @@ def verify_solution(
     expires = extract_params(payload).get("expires")
     try:
         if check_expires and expires and int(expires[0]) < time.time():
-            return False, None
+            return False, "Altcha payload expired"
     except ValueError:  # Guard against malformed expires
-        return False, None
+        return False, "Altcha payload expired"
 
     options = ChallengeOptions(
         algorithm=payload["algorithm"],


### PR DESCRIPTION
`verify_solution()` can check for expiration, but just returns `False, None` in the case of an expired payload. I'm proposing a more helpful message to the user by returning `False, "Altcha payload expired"`, like `verify_server_signature()` already returns.

Probably it would be even better to replace these magic return strings with an enum, so that the user has a better way to check for all of them without having to consult the codebase for the exact string values every time.